### PR TITLE
feat: support for custom user extensions

### DIFF
--- a/LeanInk/Analysis/Basic.lean
+++ b/LeanInk/Analysis/Basic.lean
@@ -60,11 +60,19 @@ def execAux (args: List ResolvedArgument) (file: String) : IO UInt32 := do
     IO.println s!"Starting Analysis for: \"{file}\""
     let config ← _buildConfiguration args file
     return ← (execAuxM.run config)
-    
+
+/-
+`enableInitializersExecution` is usually only run from the C part of the
+frontend and needs to be used with care but it is required in order
+to work with custom user extensions correctly.
+-/
+@[implementedBy enableInitializersExecution]
+private def enableInitializersExecutionWrapper : IO Unit := pure ()
 
 def exec (args: List ResolvedArgument) : List String -> IO UInt32
   | [] => do Logger.logError s!"No input files provided"
   | files => do
+    enableInitializersExecutionWrapper
     -- Span task for every file?
     for file in files do
       if (← execAux args file) != 0 then

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ leanInk a Input.lean
 
 The `analyze` command will generate an output file `Input.lean.leanInk` with the annotate lean program, encoded using Alectryons fragment json format. (For more information about the json format take a look at [Alectryon.lean](https://github.com/leanprover/LeanInk/blob/main/LeanInk/Annotation/Alectryon.lean))
 
---- 
+---
 
 If your lean program has external dependencies and uses Lake as its package manager you can use the `--lake` argument to provide the lakefile.
 


### PR DESCRIPTION
## Description
When running LeanInk against files that load custom user extensions which
make user of initializers right now it will simply error because those
initializers aren't run. This is addressed by telling the frontend to
run the initializers.
