### PR TITLE
chore: pin a Mathlib commit for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ For more information about Alectryon make sure to take a look at their repositor
 
 # Development
 
+## Updating
+
+When updating the `lean-toolchain`, please also:
+* update `test/dep/lean-toolchain` to match,
+* change the Mathlib commit in `test/dep.lakefile.lean` to a commit of Mathlib using the same toolchain,
+* run `lake update` in `test/dep/` to update the `lake-manifest.json`.
+
 ## Experimental Features
 
 ### Additional Type Hover Metadata

--- a/test/dep/lake-manifest.json
+++ b/test/dep/lake-manifest.json
@@ -4,9 +4,9 @@
  [{"git":
    {"url": "https://github.com/leanprover-community/mathlib4.git",
     "subDir?": null,
-    "rev": "9543173939e94784b16060bcd932c99387e30bb7",
+    "rev": "3d5d1404a27f4b285302a1589e1da2672590da34",
     "name": "mathlib",
-    "inputRev?": "master"}},
+    "inputRev?": "3d5d1404a27f4b285302a1589e1da2672590da34"}},
   {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,

--- a/test/dep/lakefile.lean
+++ b/test/dep/lakefile.lean
@@ -3,7 +3,7 @@ open Lake DSL
 
 package dep
 
-require mathlib from git "https://github.com/leanprover-community/mathlib4.git" @ "master"
+require mathlib from git "https://github.com/leanprover-community/mathlib4.git" @ "3d5d1404a27f4b285302a1589e1da2672590da34"
 
 @[default_target]
 lean_lib dep

--- a/test/dep/lean-toolchain
+++ b/test/dep/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:nightly-2023-04-07


### PR DESCRIPTION
## Description

Currently the `tests/dep/` folder has a lakefile that points to Mathlib's `master` branch. As this can move without this repo moving, it means testing is not reproducible.

Instead, we should pin a commit of Mathlib here.

I have added a note to the "Development" section of README.md to remind that this should be updated along with the `lean-toolchain`.